### PR TITLE
Implement minimal LinkedIn-like demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
-# link
-link
+# LinkD
+
+This repository contains a minimal LinkedIn-style demo built with [Expo](https://expo.dev) and the Expo Router. The application provides a simple login screen and two main tabs: a feed of posts and a basic profile page.
+
+## Running the app
+
+1. Install dependencies
+
+   ```bash
+   npm install --prefix linkD
+   ```
+
+2. Start the development server
+
+   ```bash
+   npx expo start --working-directory linkD
+   ```
+
+Open the web preview from the Expo CLI to interact with the demo.

--- a/linkD/app/(tabs)/_layout.tsx
+++ b/linkD/app/(tabs)/_layout.tsx
@@ -1,0 +1,27 @@
+import { Tabs } from "expo-router";
+import { Ionicons } from "@expo/vector-icons";
+
+export default function TabLayout() {
+  return (
+    <Tabs>
+      <Tabs.Screen
+        name="feed"
+        options={{
+          title: "Feed",
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="home" size={size} color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="profile"
+        options={{
+          title: "Profile",
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="person" size={size} color={color} />
+          ),
+        }}
+      />
+    </Tabs>
+  );
+}

--- a/linkD/app/(tabs)/feed.tsx
+++ b/linkD/app/(tabs)/feed.tsx
@@ -1,0 +1,35 @@
+import { View, Text, StyleSheet, FlatList } from "react-native";
+
+const posts = [
+  { id: "1", author: "Jane Doe", content: "Excited to join this new platform!" },
+  { id: "2", author: "John Smith", content: "Just published a new blog post." },
+];
+
+export default function FeedScreen() {
+  return (
+    <View style={styles.container}>
+      <FlatList
+        data={posts}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => (
+          <View style={styles.post}>
+            <Text style={styles.author}>{item.author}</Text>
+            <Text>{item.content}</Text>
+          </View>
+        )}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 16 },
+  post: {
+    backgroundColor: "#fff",
+    padding: 12,
+    marginBottom: 12,
+    borderRadius: 6,
+    elevation: 1,
+  },
+  author: { fontWeight: "bold", marginBottom: 4 },
+});

--- a/linkD/app/(tabs)/profile.tsx
+++ b/linkD/app/(tabs)/profile.tsx
@@ -1,0 +1,35 @@
+import { View, Text, StyleSheet, Image } from "react-native";
+
+export default function ProfileScreen() {
+  return (
+    <View style={styles.container}>
+      <Image
+        source={{ uri: "https://placekitten.com/200/200" }}
+        style={styles.avatar}
+      />
+      <Text style={styles.name}>Jane Doe</Text>
+      <Text style={styles.title}>Software Developer</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  avatar: {
+    width: 120,
+    height: 120,
+    borderRadius: 60,
+    marginBottom: 16,
+  },
+  name: {
+    fontSize: 20,
+    fontWeight: "bold",
+  },
+  title: {
+    color: "#666",
+  },
+});

--- a/linkD/app/_layout.tsx
+++ b/linkD/app/_layout.tsx
@@ -1,5 +1,7 @@
 import { Stack } from "expo-router";
 
 export default function RootLayout() {
-  return <Stack />;
+  return (
+    <Stack screenOptions={{ headerShown: false }} />
+  );
 }

--- a/linkD/app/index.tsx
+++ b/linkD/app/index.tsx
@@ -1,15 +1,25 @@
-import { Text, View } from "react-native";
+import { View, Text, Button, StyleSheet } from "react-native";
+import { useRouter } from "expo-router";
 
-export default function Index() {
+export default function LoginScreen() {
+  const router = useRouter();
   return (
-    <View
-      style={{
-        flex: 1,
-        justifyContent: "center",
-        alignItems: "center",
-      }}
-    >
-      <Text>Edit app/index.tsx to edit this screen.</Text>
+    <View style={styles.container}>
+      <Text style={styles.title}>Welcome to LinkD</Text>
+      <Button title="Sign In" onPress={() => router.replace("/(tabs)/feed") } />
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 16,
+  },
+  title: {
+    fontSize: 24,
+    marginBottom: 16,
+  },
+});


### PR DESCRIPTION
## Summary
- update root README with instructions
- add Expo router tab layout
- create feed and profile screens
- implement login screen with navigation to tabs
- hide headers in root stack

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e5e17481c832bb04ed2f153faf10e