### PR TITLE
Fix sign up navigation

### DIFF
--- a/linkD/app/sign-up.tsx
+++ b/linkD/app/sign-up.tsx
@@ -34,8 +34,11 @@ export default function SignUpScreen() {
         value={password}
         onChangeText={setPassword}
       />
-      <Button mode="contained" onPress={handleSignUp}>
+      <Button mode="contained" onPress={handleSignUp} style={styles.signUpButton}>
         Sign Up
+      </Button>
+      <Button mode="text" onPress={() => router.back()}>
+        Back
       </Button>
     </View>
   );
@@ -49,5 +52,8 @@ const styles = StyleSheet.create({
   },
   input: {
     marginBottom: 12,
+  },
+  signUpButton: {
+    marginBottom: 8,
   },
 });


### PR DESCRIPTION
## Summary
- add a back button so users can exit the Sign Up screen

## Testing
- `npm run lint --prefix linkD` *(fails: 403 Forbidden - GET https://registry.npmjs.org/expo)*

------
https://chatgpt.com/codex/tasks/task_e_685e6892bd0c832b88289b0f96284d60