### PR TITLE
Add chat placeholder and post actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # LinkD
 
-This repository contains a minimal LinkedIn-style demo built with [Expo](https://expo.dev), a small [Next.js](https://nextjs.org) backend and [Supabase](https://supabase.com) for authentication and data storage. The Expo app uses **React Native Paper** for a dark UI with purple accents and Supabase Auth for signing in and creating accounts, while the Next.js API exposes helper endpoints.
+This repository contains a minimal LinkedIn-style demo built with [Expo](https://expo.dev), a small [Next.js](https://nextjs.org) backend and [Supabase](https://supabase.com) for authentication and data storage. The Expo app uses **React Native Paper** for a dark UI with purple accents and Supabase Auth for signing in and creating accounts, while the Next.js API exposes helper endpoints. UI screens now include themed backgrounds and card-based forms for a cleaner look.
+
+## Features
+- User authentication with Supabase
+- Create posts and browse the feed
+- Profile page with placeholder details
+- New chat tab for future messaging
+- Like and comment buttons on posts (placeholders)
 
 ## Running the app
 

--- a/linkD/app/(tabs)/_layout.tsx
+++ b/linkD/app/(tabs)/_layout.tsx
@@ -14,6 +14,15 @@ export default function TabLayout() {
         }}
       />
       <Tabs.Screen
+        name="chat"
+        options={{
+          title: "Chat",
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="chatbubble" size={size} color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
         name="profile"
         options={{
           title: "Profile",

--- a/linkD/app/(tabs)/chat.tsx
+++ b/linkD/app/(tabs)/chat.tsx
@@ -1,0 +1,20 @@
+import { View, Text, StyleSheet } from 'react-native';
+import { useTheme } from 'react-native-paper';
+
+export default function ChatScreen() {
+  const theme = useTheme();
+  return (
+    <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
+      <Text style={[styles.placeholder, { color: theme.colors.onBackground }]}>Chat coming soon...</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  placeholder: {},
+});

--- a/linkD/app/(tabs)/feed.tsx
+++ b/linkD/app/(tabs)/feed.tsx
@@ -1,5 +1,5 @@
 import { View, Text, StyleSheet, FlatList, RefreshControl } from 'react-native';
-import { Button, Card } from 'react-native-paper';
+import { Button, Card, IconButton, useTheme } from 'react-native-paper';
 import { useEffect, useState } from 'react';
 import { supabase } from '@/lib/supabase';
 import { useRouter } from 'expo-router';
@@ -14,6 +14,7 @@ export default function FeedScreen() {
   const [posts, setPosts] = useState<Post[]>([]);
   const [refreshing, setRefreshing] = useState(false);
   const router = useRouter();
+  const theme = useTheme();
 
   async function fetchPosts() {
     const { data } = await supabase.from('posts').select('*').order('created_at', { ascending: false });
@@ -31,7 +32,7 @@ export default function FeedScreen() {
   };
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, { backgroundColor: theme.colors.background }]}> 
       <Button mode="contained" onPress={() => router.push('/create-post')} style={styles.createButton}>
         Create Post
       </Button>
@@ -40,11 +41,15 @@ export default function FeedScreen() {
         keyExtractor={(item) => item.id}
         refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
         renderItem={({ item }) => (
-          <Card style={styles.post}>
+          <Card style={[styles.post, { backgroundColor: theme.colors.elevation.level1 }]}>
             <Card.Title title={item.author} titleStyle={styles.author} />
             <Card.Content>
               <Text>{item.content}</Text>
             </Card.Content>
+            <Card.Actions>
+              <IconButton icon="heart-outline" onPress={() => {}} />
+              <IconButton icon="chat-outline" onPress={() => {}} />
+            </Card.Actions>
           </Card>
         )}
       />
@@ -56,11 +61,9 @@ const styles = StyleSheet.create({
   container: { flex: 1, padding: 16 },
   createButton: { marginBottom: 12 },
   post: {
-    backgroundColor: '#fff',
     padding: 12,
     marginBottom: 12,
     borderRadius: 6,
-    elevation: 1,
   },
   author: { fontWeight: 'bold', marginBottom: 4 },
 });

--- a/linkD/app/(tabs)/profile.tsx
+++ b/linkD/app/(tabs)/profile.tsx
@@ -1,10 +1,11 @@
 import { View, Text, StyleSheet, Image } from 'react-native';
-import { Button } from 'react-native-paper';
+import { Button, useTheme } from 'react-native-paper';
 import { supabase } from '@/lib/supabase';
 import { useRouter } from 'expo-router';
 
 export default function ProfileScreen() {
   const router = useRouter();
+  const theme = useTheme();
 
   async function handleSignOut() {
     await supabase.auth.signOut();
@@ -12,13 +13,13 @@ export default function ProfileScreen() {
   }
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
       <Image
         source={{ uri: 'https://placekitten.com/200/200' }}
         style={styles.avatar}
       />
       <Text style={styles.name}>Jane Doe</Text>
-      <Text style={styles.title}>Software Developer</Text>
+      <Text style={[styles.title, { color: theme.colors.onBackground }]}>Software Developer</Text>
       <Button mode="contained" onPress={handleSignOut}>
         Sign Out
       </Button>
@@ -42,7 +43,5 @@ const styles = StyleSheet.create({
     fontSize: 20,
     fontWeight: "bold",
   },
-  title: {
-    color: "#666",
-  },
+  title: {},
 });

--- a/linkD/app/_layout.tsx
+++ b/linkD/app/_layout.tsx
@@ -12,7 +12,7 @@ const theme = {
 export default function RootLayout() {
   return (
     <PaperProvider theme={theme}>
-      <Stack screenOptions={{ headerShown: false }} />
+      <Stack screenOptions={{ headerShown: false, contentStyle: { backgroundColor: theme.colors.background } }} />
     </PaperProvider>
   );
 }

--- a/linkD/app/create-post.tsx
+++ b/linkD/app/create-post.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react';
 import { View, StyleSheet, Alert } from 'react-native';
-import { TextInput, Button } from 'react-native-paper';
+import { TextInput, Button, useTheme } from 'react-native-paper';
 import { supabase } from '@/lib/supabase';
 import { useRouter } from 'expo-router';
 
 export default function CreatePostScreen() {
   const [content, setContent] = useState('');
   const router = useRouter();
+  const theme = useTheme();
 
   async function handleCreate() {
     if (!content) return;
@@ -24,7 +25,7 @@ export default function CreatePostScreen() {
   }
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
       <TextInput
         label="What's on your mind?"
         value={content}

--- a/linkD/app/index.tsx
+++ b/linkD/app/index.tsx
@@ -1,11 +1,12 @@
 import { View, Text, StyleSheet } from 'react-native';
-import { Button } from 'react-native-paper';
+import { Button, useTheme } from 'react-native-paper';
 import { useRouter } from 'expo-router';
 
 export default function LandingScreen() {
   const router = useRouter();
+  const theme = useTheme();
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
       <Text style={styles.title}>Welcome to LinkD</Text>
       <Button mode="contained" onPress={() => router.push('/sign-in')} style={styles.button}>
         Sign In

--- a/linkD/app/sign-in.tsx
+++ b/linkD/app/sign-in.tsx
@@ -1,11 +1,12 @@
 import { useState } from 'react';
 import { View, StyleSheet, Alert } from 'react-native';
-import { TextInput, Button } from 'react-native-paper';
+import { TextInput, Button, Card, useTheme } from 'react-native-paper';
 import { supabase } from '@/lib/supabase';
 import { useRouter } from 'expo-router';
 
 export default function SignInScreen() {
   const router = useRouter();
+  const theme = useTheme();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
 
@@ -19,24 +20,29 @@ export default function SignInScreen() {
   }
 
   return (
-    <View style={styles.container}>
-      <TextInput
-        label="Email"
-        autoCapitalize="none"
-        style={styles.input}
-        value={email}
-        onChangeText={setEmail}
-      />
-      <TextInput
-        label="Password"
-        secureTextEntry
-        style={styles.input}
-        value={password}
-        onChangeText={setPassword}
-      />
-      <Button mode="contained" onPress={handleSignIn}>
-        Sign In
-      </Button>
+    <View style={[styles.container, { backgroundColor: theme.colors.background }]}> 
+      <Card style={styles.card}>
+        <Card.Title title="Sign In" />
+        <Card.Content>
+          <TextInput
+            label="Email"
+            autoCapitalize="none"
+            style={styles.input}
+            value={email}
+            onChangeText={setEmail}
+          />
+          <TextInput
+            label="Password"
+            secureTextEntry
+            style={styles.input}
+            value={password}
+            onChangeText={setPassword}
+          />
+          <Button mode="contained" onPress={handleSignIn}>
+            Sign In
+          </Button>
+        </Card.Content>
+      </Card>
     </View>
   );
 }
@@ -45,6 +51,9 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: 'center',
+    padding: 16,
+  },
+  card: {
     padding: 16,
   },
   input: {

--- a/linkD/app/sign-up.tsx
+++ b/linkD/app/sign-up.tsx
@@ -1,11 +1,12 @@
 import { useState } from 'react';
 import { View, StyleSheet, Alert } from 'react-native';
-import { TextInput, Button } from 'react-native-paper';
+import { TextInput, Button, Card, useTheme } from 'react-native-paper';
 import { supabase } from '@/lib/supabase';
 import { useRouter } from 'expo-router';
 
 export default function SignUpScreen() {
   const router = useRouter();
+  const theme = useTheme();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
 
@@ -19,27 +20,30 @@ export default function SignUpScreen() {
   }
 
   return (
-    <View style={styles.container}>
-      <TextInput
-        label="Email"
-        autoCapitalize="none"
-        style={styles.input}
-        value={email}
-        onChangeText={setEmail}
-      />
-      <TextInput
-        label="Password"
-        secureTextEntry
-        style={styles.input}
-        value={password}
-        onChangeText={setPassword}
-      />
-      <Button mode="contained" onPress={handleSignUp} style={styles.signUpButton}>
-        Sign Up
-      </Button>
-      <Button mode="text" onPress={() => router.back()}>
-        Back
-      </Button>
+    <View style={[styles.container, { backgroundColor: theme.colors.background }]}> 
+      <Card style={styles.card}>
+        <Card.Title title="Create Account" />
+        <Card.Content>
+          <TextInput
+            label="Email"
+            autoCapitalize="none"
+            style={styles.input}
+            value={email}
+            onChangeText={setEmail}
+          />
+          <TextInput
+            label="Password"
+            secureTextEntry
+            style={styles.input}
+            value={password}
+            onChangeText={setPassword}
+          />
+          <Button mode="contained" onPress={handleSignUp} style={styles.signUpButton}>
+            Sign Up
+          </Button>
+          <Button mode="text" onPress={() => router.back()}>Back</Button>
+        </Card.Content>
+      </Card>
     </View>
   );
 }
@@ -48,6 +52,9 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: 'center',
+    padding: 16,
+  },
+  card: {
     padding: 16,
   },
   input: {


### PR DESCRIPTION
## Summary
- add new Chat tab with placeholder screen
- show like/comment buttons on posts
- document features in the README
- improve dark theme with styled backgrounds and card-based forms

## Testing
- `npm run lint --prefix linkD` *(fails: 403 Forbidden from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_685e6e3cc56c832bb46e9be7955e0121