### PR TITLE
Improve responsive layout

### DIFF
--- a/linkD/app/(tabs)/feed.tsx
+++ b/linkD/app/(tabs)/feed.tsx
@@ -1,4 +1,5 @@
 import { View, Text, StyleSheet, FlatList, RefreshControl } from 'react-native';
+import ResponsiveContainer from '@/components/ResponsiveContainer';
 import { Button, Card, IconButton, useTheme } from 'react-native-paper';
 import { useEffect, useState } from 'react';
 import { supabase } from '@/lib/supabase';
@@ -32,33 +33,36 @@ export default function FeedScreen() {
   };
 
   return (
-    <View style={[styles.container, { backgroundColor: theme.colors.background }]}> 
-      <Button mode="contained" onPress={() => router.push('/create-post')} style={styles.createButton}>
-        Create Post
-      </Button>
-      <FlatList
-        data={posts}
-        keyExtractor={(item) => item.id}
-        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
-        renderItem={({ item }) => (
-          <Card style={[styles.post, { backgroundColor: theme.colors.elevation.level1 }]}>
-            <Card.Title title={item.author} titleStyle={styles.author} />
-            <Card.Content>
-              <Text>{item.content}</Text>
-            </Card.Content>
-            <Card.Actions>
-              <IconButton icon="heart-outline" onPress={() => {}} />
-              <IconButton icon="chat-outline" onPress={() => {}} />
-            </Card.Actions>
-          </Card>
-        )}
-      />
+    <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
+      <ResponsiveContainer style={styles.inner}>
+        <Button mode="contained" onPress={() => router.push('/create-post')} style={styles.createButton}>
+          Create Post
+        </Button>
+        <FlatList
+          data={posts}
+          keyExtractor={(item) => item.id}
+          refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+          renderItem={({ item }) => (
+            <Card style={[styles.post, { backgroundColor: theme.colors.elevation.level1 }]}>
+              <Card.Title title={item.author} titleStyle={styles.author} />
+              <Card.Content>
+                <Text>{item.content}</Text>
+              </Card.Content>
+              <Card.Actions>
+                <IconButton icon="heart-outline" onPress={() => {}} />
+                <IconButton icon="chat-outline" onPress={() => {}} />
+              </Card.Actions>
+            </Card>
+          )}
+        />
+      </ResponsiveContainer>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
   container: { flex: 1, padding: 16 },
+  inner: { flex: 1 },
   createButton: { marginBottom: 12 },
   post: {
     padding: 12,

--- a/linkD/app/(tabs)/profile.tsx
+++ b/linkD/app/(tabs)/profile.tsx
@@ -1,4 +1,5 @@
 import { View, Text, StyleSheet, Image } from 'react-native';
+import ResponsiveContainer from '@/components/ResponsiveContainer';
 import { Button, useTheme } from 'react-native-paper';
 import { supabase } from '@/lib/supabase';
 import { useRouter } from 'expo-router';
@@ -14,15 +15,17 @@ export default function ProfileScreen() {
 
   return (
     <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
-      <Image
-        source={{ uri: 'https://placekitten.com/200/200' }}
-        style={styles.avatar}
-      />
-      <Text style={styles.name}>Jane Doe</Text>
-      <Text style={[styles.title, { color: theme.colors.onBackground }]}>Software Developer</Text>
-      <Button mode="contained" onPress={handleSignOut}>
-        Sign Out
-      </Button>
+      <ResponsiveContainer style={styles.inner}>
+        <Image
+          source={{ uri: 'https://placekitten.com/200/200' }}
+          style={styles.avatar}
+        />
+        <Text style={styles.name}>Jane Doe</Text>
+        <Text style={[styles.title, { color: theme.colors.onBackground }]}>Software Developer</Text>
+        <Button mode="contained" onPress={handleSignOut}>
+          Sign Out
+        </Button>
+      </ResponsiveContainer>
     </View>
   );
 }
@@ -32,6 +35,9 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: "center",
     justifyContent: "center",
+  },
+  inner: {
+    alignItems: "center",
   },
   avatar: {
     width: 120,

--- a/linkD/app/create-post.tsx
+++ b/linkD/app/create-post.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { View, StyleSheet, Alert } from 'react-native';
+import ResponsiveContainer from '@/components/ResponsiveContainer';
 import { TextInput, Button, useTheme } from 'react-native-paper';
 import { supabase } from '@/lib/supabase';
 import { useRouter } from 'expo-router';
@@ -26,16 +27,18 @@ export default function CreatePostScreen() {
 
   return (
     <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
-      <TextInput
-        label="What's on your mind?"
-        value={content}
-        onChangeText={setContent}
-        multiline
-        style={styles.input}
-      />
-      <Button mode="contained" onPress={handleCreate}>
-        Post
-      </Button>
+      <ResponsiveContainer>
+        <TextInput
+          label="What's on your mind?"
+          value={content}
+          onChangeText={setContent}
+          multiline
+          style={styles.input}
+        />
+        <Button mode="contained" onPress={handleCreate}>
+          Post
+        </Button>
+      </ResponsiveContainer>
     </View>
   );
 }

--- a/linkD/app/sign-in.tsx
+++ b/linkD/app/sign-in.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { View, StyleSheet, Alert } from 'react-native';
+import ResponsiveContainer from '@/components/ResponsiveContainer';
 import { TextInput, Button, Card, useTheme } from 'react-native-paper';
 import { supabase } from '@/lib/supabase';
 import { useRouter } from 'expo-router';
@@ -20,29 +21,31 @@ export default function SignInScreen() {
   }
 
   return (
-    <View style={[styles.container, { backgroundColor: theme.colors.background }]}> 
-      <Card style={styles.card}>
-        <Card.Title title="Sign In" />
-        <Card.Content>
-          <TextInput
-            label="Email"
-            autoCapitalize="none"
-            style={styles.input}
-            value={email}
-            onChangeText={setEmail}
-          />
-          <TextInput
-            label="Password"
-            secureTextEntry
-            style={styles.input}
-            value={password}
-            onChangeText={setPassword}
-          />
-          <Button mode="contained" onPress={handleSignIn}>
-            Sign In
-          </Button>
-        </Card.Content>
-      </Card>
+    <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
+      <ResponsiveContainer>
+        <Card style={styles.card}>
+          <Card.Title title="Sign In" />
+          <Card.Content>
+            <TextInput
+              label="Email"
+              autoCapitalize="none"
+              style={styles.input}
+              value={email}
+              onChangeText={setEmail}
+            />
+            <TextInput
+              label="Password"
+              secureTextEntry
+              style={styles.input}
+              value={password}
+              onChangeText={setPassword}
+            />
+            <Button mode="contained" onPress={handleSignIn}>
+              Sign In
+            </Button>
+          </Card.Content>
+        </Card>
+      </ResponsiveContainer>
     </View>
   );
 }

--- a/linkD/app/sign-up.tsx
+++ b/linkD/app/sign-up.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { View, StyleSheet, Alert } from 'react-native';
+import ResponsiveContainer from '@/components/ResponsiveContainer';
 import { TextInput, Button, Card, useTheme } from 'react-native-paper';
 import { supabase } from '@/lib/supabase';
 import { useRouter } from 'expo-router';
@@ -20,30 +21,32 @@ export default function SignUpScreen() {
   }
 
   return (
-    <View style={[styles.container, { backgroundColor: theme.colors.background }]}> 
-      <Card style={styles.card}>
-        <Card.Title title="Create Account" />
-        <Card.Content>
-          <TextInput
-            label="Email"
-            autoCapitalize="none"
-            style={styles.input}
-            value={email}
-            onChangeText={setEmail}
-          />
-          <TextInput
-            label="Password"
-            secureTextEntry
-            style={styles.input}
-            value={password}
-            onChangeText={setPassword}
-          />
-          <Button mode="contained" onPress={handleSignUp} style={styles.signUpButton}>
-            Sign Up
-          </Button>
-          <Button mode="text" onPress={() => router.back()}>Back</Button>
-        </Card.Content>
-      </Card>
+    <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
+      <ResponsiveContainer>
+        <Card style={styles.card}>
+          <Card.Title title="Create Account" />
+          <Card.Content>
+            <TextInput
+              label="Email"
+              autoCapitalize="none"
+              style={styles.input}
+              value={email}
+              onChangeText={setEmail}
+            />
+            <TextInput
+              label="Password"
+              secureTextEntry
+              style={styles.input}
+              value={password}
+              onChangeText={setPassword}
+            />
+            <Button mode="contained" onPress={handleSignUp} style={styles.signUpButton}>
+              Sign Up
+            </Button>
+            <Button mode="text" onPress={() => router.back()}>Back</Button>
+          </Card.Content>
+        </Card>
+      </ResponsiveContainer>
     </View>
   );
 }

--- a/linkD/components/ResponsiveContainer.tsx
+++ b/linkD/components/ResponsiveContainer.tsx
@@ -1,0 +1,23 @@
+import { View, useWindowDimensions, StyleSheet, ViewStyle } from 'react-native';
+import { ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+  style?: ViewStyle;
+}
+
+export default function ResponsiveContainer({ children, style }: Props) {
+  const { width } = useWindowDimensions();
+  const maxWidth = 600;
+  const contentWidth: number | string = width > maxWidth ? maxWidth : '100%';
+
+  return (
+    <View style={[styles.container, { width: contentWidth }, style]}>{children}</View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignSelf: 'center',
+  },
+});


### PR DESCRIPTION
## Summary
- create `ResponsiveContainer` component for better scaling on web
- wrap feed and profile tabs as well as create/sign-in/sign-up screens with the responsive container

## Testing
- `npm run lint --prefix linkD` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685e7149b7f8832b9846950ea0a32280